### PR TITLE
Add support for HTTPS servers using Zephyr

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -14721,6 +14721,14 @@ set_ports_option(struct mg_context *phys_ctx)
 
 #if defined(__ZEPHYR__)
 		if (so.is_ssl) {
+			if (phys_ctx->dd.config[SSL_CERTIFICATE] == NULL) {
+				mg_cry_ctx_internal(
+					phys_ctx,
+					"Initializing SSL failed: %s is not set",
+					config_options[SSL_CERTIFICATE].name);
+				continue;
+			}
+
 			crt_tag = atoi(phys_ctx->dd.config[SSL_CERTIFICATE]);
 
 			if (setsockopt(so.sock,


### PR DESCRIPTION
This PR proposes modifications to add the support for running HTTPS servers with Zephyr using Zephyr Secure Sockets.

Using Secure Sockets enables in particular to easily supply the TLS certificate and private key since it is enough to add them to TLS Credentials subsystem and to provide the corresponding tag through the CivetWeb configuration.

Note that TLS support is not added for the HTTP client API.